### PR TITLE
[feat] results box visible based on errors

### DIFF
--- a/src/app/check-file-result/check-file-result.component.html
+++ b/src/app/check-file-result/check-file-result.component.html
@@ -1,9 +1,9 @@
-<mat-card>
+<mat-card [attr.data-test]="this['data-test']">
   <mat-card-header>
     <mat-card-title>File parse result</mat-card-title>
   </mat-card-header>
   <mat-card-content>
-    <div *ngIf="parseErrors?.length > 0">
+    <div *ngIf="parseErrors?.length > 0" data-test="check-file-result--errors">
       <table mat-table [dataSource]="parseErrors" class="mat-elevation-z8">
         <ng-container matColumnDef="key">
           <th mat-header-cell *matHeaderCellDef>Key</th>
@@ -34,6 +34,12 @@
           Export as Excel
         </button>
       </div>
+    </div>
+    <div
+      *ngIf="parseErrors && parseErrors.length === 0"
+      data-test="check-file-result--no-errors-message"
+    >
+      ✅ Everything is okay, no format errors were found.
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/check-file-result/check-file-result.component.spec.ts
+++ b/src/app/check-file-result/check-file-result.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FileParseError } from '../models/file-parse-error';
+import { By } from '@angular/platform-browser';
 
 import { CheckFileResultComponent } from './check-file-result.component';
+import { MatCardModule } from '@angular/material/card';
 
 describe('CheckFileResultComponent', () => {
   let component: CheckFileResultComponent;
@@ -9,7 +12,8 @@ describe('CheckFileResultComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [CheckFileResultComponent]
+        declarations: [CheckFileResultComponent],
+        imports: [MatCardModule]
       }).compileComponents();
     })
   );
@@ -22,5 +26,50 @@ describe('CheckFileResultComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('if there are parse errors then show details', () => {
+    component.parseErrors = [new FileParseError('test', 'test', 'test')];
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(
+        By.css(`[data-test="check-file-result--errors"]`)
+      )
+    ).toBeTruthy();
+    expect(
+      fixture.debugElement.query(
+        By.css(`[data-test="check-file-result--no-errors-message"]`)
+      )
+    ).not.toBeTruthy();
+  });
+
+  it('if there are not parse errors then show message', () => {
+    component.parseErrors = [];
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(
+        By.css(`[data-test="check-file-result--errors"]`)
+      )
+    ).not.toBeTruthy();
+    expect(
+      fixture.debugElement.query(
+        By.css(`[data-test="check-file-result--no-errors-message"]`)
+      )
+    ).toBeTruthy();
+  });
+
+  it('if there are not parse errors data available then hide content', () => {
+    component.parseErrors = null;
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(
+        By.css(`[data-test="check-file-result--errors"]`)
+      )
+    ).not.toBeTruthy();
+    expect(
+      fixture.debugElement.query(
+        By.css(`[data-test="check-file-result--no-errors-message"]`)
+      )
+    ).not.toBeTruthy();
   });
 });

--- a/src/app/check-file-result/check-file-result.component.ts
+++ b/src/app/check-file-result/check-file-result.component.ts
@@ -20,7 +20,6 @@ export class CheckFileResultComponent {
   public parseErrors: FileParseError[];
 
   @Input()
-  @Input()
   public fileInfo: FileInfo;
 
   exportAsExcel() {

--- a/src/app/check-file-result/check-file-result.component.ts
+++ b/src/app/check-file-result/check-file-result.component.ts
@@ -10,10 +10,16 @@ import { FileInfo } from '../models/file-info';
 })
 export class CheckFileResultComponent {
   displayedColumns: string[] = ['key', 'message', 'error'];
+  ['data-test']: string;
+
+  constructor(element: ElementRef) {
+    this['data-test'] = element.nativeElement.getAttribute('data-test');
+  }
 
   @Input()
   public parseErrors: FileParseError[];
 
+  @Input()
   @Input()
   public fileInfo: FileInfo;
 

--- a/src/app/check-file/check-file.component.html
+++ b/src/app/check-file/check-file.component.html
@@ -1,10 +1,14 @@
 <div>
   <app-file-upload-form
+    [attr.data-test]="'app-check-file--form'"
     (fileChange)="onFileChange($event)"
+    (submitFile)="onSubmitFile($event)"
   ></app-file-upload-form>
 </div>
 <div>
   <app-check-file-result
+    [attr.data-test]="'app-check-file--result'"
+    *ngIf="fileParseErrors"
     [parseErrors]="fileParseErrors"
     [fileInfo]="fileInfo"
   ></app-check-file-result>

--- a/src/app/check-file/check-file.component.spec.ts
+++ b/src/app/check-file/check-file.component.spec.ts
@@ -1,4 +1,22 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTableModule } from '@angular/material/table';
+import { MatTabsModule } from '@angular/material/tabs';
+import { BrowserModule, By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CheckFileResultComponent } from '../check-file-result/check-file-result.component';
+import { CheckMessageComponent } from '../check-message/check-message.component';
+import { FileUploadFormComponent } from '../file-upload-form/file-upload-form.component';
+import { FileInfo } from '../models/file-info';
+import { FileParseError } from '../models/file-parse-error';
 
 import { CheckFileComponent } from './check-file.component';
 
@@ -9,7 +27,28 @@ describe('CheckFileComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [CheckFileComponent]
+        declarations: [
+          CheckFileComponent,
+          FileUploadFormComponent,
+          CheckFileResultComponent,
+          CheckMessageComponent
+        ],
+        imports: [
+          BrowserModule,
+          FormsModule,
+          BrowserAnimationsModule,
+          ReactiveFormsModule,
+          MatCardModule,
+          MatInputModule,
+          MatButtonModule,
+          MatSelectModule,
+          MatRadioModule,
+          MatCheckboxModule,
+          MatChipsModule,
+          MatIconModule,
+          MatTabsModule,
+          MatTableModule
+        ]
       }).compileComponents();
     })
   );
@@ -22,5 +61,56 @@ describe('CheckFileComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should remove fileParseErrors on file change', () => {
+    const fileInfo: FileInfo = {
+      language: 'es',
+      fileContent: {},
+      allowList: ['CORE'],
+      rawFile: new File([''], 'test')
+    };
+    component.fileParseErrors = [];
+    component.onFileChange(fileInfo);
+    expect(component.fileParseErrors).toBeNull();
+  });
+
+  it('should not show results if errors are not defined', () => {
+    component.fileParseErrors = null;
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css(`[data-test=app-check-file--result]`))
+    ).not.toBeTruthy();
+  });
+
+  it('should show results if errors array is empty', () => {
+    component.fileParseErrors = [];
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css(`[data-test=app-check-file--result]`))
+    ).toBeTruthy();
+  });
+
+  it('should show results if errors array has content', () => {
+    component.fileParseErrors = [new FileParseError('test', 'test', 'test')];
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css(`[data-test=app-check-file--result]`))
+    ).toBeTruthy();
+  });
+
+  it('submit form should trigger check file', () => {
+    const form: FileUploadFormComponent = fixture.debugElement.query(
+      By.css(`[data-test=app-check-file--form]`)
+    )?.componentInstance;
+    const spy = spyOn(component, 'onSubmitFile');
+    form.submitFile.emit({
+      language: 'es',
+      fileContent: {},
+      allowList: ['CORE'],
+      rawFile: new File([''], 'test')
+    });
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/check-file/check-file.component.ts
+++ b/src/app/check-file/check-file.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit } from '@angular/core';
 import { FileInfo } from '../models/file-info';
 import { FileParseError } from '../models/file-parse-error';
 import { FileParsingService } from '../services/file-parsing.service';
@@ -9,13 +9,23 @@ import { FileParsingService } from '../services/file-parsing.service';
   styleUrls: ['./check-file.component.scss']
 })
 export class CheckFileComponent {
-  public fileParseErrors: FileParseError[] = [];
+  public fileParseErrors: FileParseError[];
   public fileInfo: FileInfo = null;
+  public ['data-test']: string;
 
-  constructor(private fileParsingService: FileParsingService) {}
+  constructor(
+    private fileParsingService: FileParsingService,
+    element: ElementRef
+  ) {
+    this['data-test'] = element.nativeElement.getAttribute('data-test');
+  }
 
   onFileChange(fileInfo: FileInfo) {
     this.fileInfo = fileInfo;
+    this.fileParseErrors = null;
+  }
+
+  onSubmitFile(fileInfo: FileInfo) {
     this.fileParseErrors = this.fileParsingService.parseFile(fileInfo);
   }
 }

--- a/src/app/file-upload-form/file-upload-form.component.html
+++ b/src/app/file-upload-form/file-upload-form.component.html
@@ -1,4 +1,8 @@
-<form [formGroup]="fileUploadForm" novalidate>
+<form
+  [formGroup]="fileUploadForm"
+  novalidate
+  [attr.data-test]="this['data-test']"
+>
   <mat-card>
     <mat-card-header>
       <mat-card-title>Upload your file</mat-card-title>

--- a/src/app/file-upload-form/file-upload-form.component.ts
+++ b/src/app/file-upload-form/file-upload-form.component.ts
@@ -23,6 +23,9 @@ export class FileUploadFormComponent {
   });
 
   @Output()
+  public submitFile = new EventEmitter<FileInfo>();
+
+  @Output()
   public fileChange = new EventEmitter<FileInfo>();
 
   constructor(
@@ -42,6 +45,7 @@ export class FileUploadFormComponent {
           fileContent: JSON.parse(reader.result.toString()),
           rawFile: file
         });
+        this.fileChange.emit(this.fileUploadForm.value);
       };
     }
   }
@@ -72,6 +76,6 @@ export class FileUploadFormComponent {
   }
 
   checkFileFormat() {
-    this.fileChange.emit(this.fileUploadForm.value);
+    this.submitFile.emit(this.fileUploadForm.value);
   }
 }

--- a/src/app/services/translation.service.spec.ts
+++ b/src/app/services/translation.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { TranslationServiceService } from './translation.service';
+import { TranslationService } from './translation.service';
 
 describe('TranslationServiceService', () => {
-  let service: TranslationServiceService;
+  let service: TranslationService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(TranslationServiceService);
+    service = TestBed.inject(TranslationService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
This feature will give the proper feedback when there are no errors.

*I bypassed the husky hook because of problems with PowerShell in Windows, but I ran manually the prettier command.

![Animation](https://user-images.githubusercontent.com/1231888/118411941-7db0fc80-b697-11eb-9170-4f141bfabe22.gif)
