### PR TITLE
🔧 Fix husky hook for various npm version

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 . "$(dirname "$0")/_/husky.sh"
 
-npx git-format-staged -f 'npx prettier --ignore-unknown --stdin-filepath "{}"' 'src/*.ts' 'src/*.js' 'src/*.html' 'src/*.json' 'src/*.scss'
+npx_version=$(npx --version)
+npx_version_major="${npx_version%%.*}"
+
+if [ "$npx_version_major" = "6" ]; then
+    ./node_modules/.bin/git-format-staged -f "npx prettier --config .prettierrc --stdin-filepath {}" "src/*.ts" "src/*.js" "src/*.html" "src/*.json" "src/*.scss";
+else
+    npx git-format-staged -f 'npx prettier --ignore-unknown --config .prettierrc --stdin-filepath "{}"' 'src/*.ts' 'src/*.js' 'src/*.html' 'src/*.json' 'src/*.scss';
+fi;


### PR DESCRIPTION
npx v6 does not work in the same way as npx v7
Using the node_modules path does not seem very clean, but it works on my
machine